### PR TITLE
Fixed Typo in setup instructions

### DIFF
--- a/colab/PedestronColab.ipynb
+++ b/colab/PedestronColab.ipynb
@@ -255,7 +255,7 @@
         "\n",
         "*  In /usr/local, you will find /usr/local/cuda, /usr/local/cuda-10.0, /usr/local/cuda-10.1. The default version is cuda and it refers to usr/local/cuda-10.1 as you can see from usr/local/cuda/version.txt \\\\\n",
         "\n",
-        "*  Rename usr/local/cuda to usr/local/cudahigher and usr/local/cuda-10.1 to usr/local/cuda\n"
+        "*  Rename usr/local/cuda to usr/local/cudahigher and usr/local/cuda-10.0 to usr/local/cuda\n"
       ]
     },
     {


### PR DESCRIPTION
Wrong cuda version (10.1) change was mentioned in the file. Changed it to the right version (10.0)