### PR TITLE
Invalid JSON fix

### DIFF
--- a/colab/PedestronColab.ipynb
+++ b/colab/PedestronColab.ipynb
@@ -5748,7 +5748,7 @@
         "outputId": "c54023d6-4054-45f2-d9a3-82d80f79f914"
       },
       "source": [
-        "Download the pretrained model from Readme.md Table !!! Links below are broken."
+        "Download the pretrained model from Readme.md Table !!! Links below are broken.",
         "!pip install gdown\n",
         "!gdown https://drive.google.com/uc?id=1B487ljaU9FxTSFaLoirOSqadZ-39QEH8 -O CascadeRCNNCP_model.pth.stu\n",
         "!mkdir /content/Pedestron/models_pretrained/ && cp CascadeRCNNCP_model.pth.stu /content/Pedestron/models_pretrained/\n",


### PR DESCRIPTION
The pedestronColab.ipynb had an invalid JSON that made the file unable to open.