### PR TITLE
WIP CUDA 11.7 support

### DIFF
--- a/mmdet/ops/dcn/functions/deform_conv.py
+++ b/mmdet/ops/dcn/functions/deform_conv.py
@@ -2,8 +2,6 @@ import torch
 from torch.autograd import Function
 from torch.nn.modules.utils import _pair
 
-from .. import deform_conv_cuda
-
 
 class DeformConvFunction(Function):
 
@@ -18,6 +16,8 @@ class DeformConvFunction(Function):
                 groups=1,
                 deformable_groups=1,
                 im2col_step=64):
+        from .. import deform_conv_cuda
+
         if input is not None and input.dim() != 4:
             raise ValueError(
                 "Expected 4D tensor as input, got {}D tensor instead.".format(

--- a/mmdet/ops/dcn/functions/deform_pool.py
+++ b/mmdet/ops/dcn/functions/deform_pool.py
@@ -1,8 +1,6 @@
 import torch
 from torch.autograd import Function
 
-from .. import deform_pool_cuda
-
 
 class DeformRoIPoolingFunction(Function):
 
@@ -19,6 +17,8 @@ class DeformRoIPoolingFunction(Function):
                 part_size=None,
                 sample_per_part=4,
                 trans_std=.0):
+        from .. import deform_pool_cuda
+
         ctx.spatial_scale = spatial_scale
         ctx.out_size = out_size
         ctx.out_channels = out_channels
@@ -48,6 +48,8 @@ class DeformRoIPoolingFunction(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        from .. import deform_pool_cuda
+
         if not grad_output.is_cuda:
             raise NotImplementedError
 

--- a/mmdet/ops/dcn/modules/deform_conv.py
+++ b/mmdet/ops/dcn/modules/deform_conv.py
@@ -4,8 +4,6 @@ import torch
 import torch.nn as nn
 from torch.nn.modules.utils import _pair
 
-from ..functions.deform_conv import deform_conv, modulated_deform_conv
-
 
 class DeformConv(nn.Module):
 
@@ -52,6 +50,8 @@ class DeformConv(nn.Module):
         self.weight.data.uniform_(-stdv, stdv)
 
     def forward(self, x, offset):
+        from ..functions.deform_conv import deform_conv
+
         return deform_conv(x, offset, self.weight, self.stride, self.padding,
                            self.dilation, self.groups, self.deformable_groups)
 
@@ -76,6 +76,8 @@ class DeformConvPack(DeformConv):
         self.conv_offset.bias.data.zero_()
 
     def forward(self, x):
+        from ..functions.deform_conv import deform_conv
+
         offset = self.conv_offset(x)
         return deform_conv(x, offset, self.weight, self.stride, self.padding,
                            self.dilation, self.groups, self.deformable_groups)
@@ -123,6 +125,8 @@ class ModulatedDeformConv(nn.Module):
             self.bias.data.zero_()
 
     def forward(self, x, offset, mask):
+        from ..functions.deform_conv import modulated_deform_conv
+
         return modulated_deform_conv(x, offset, mask, self.weight, self.bias,
                                      self.stride, self.padding, self.dilation,
                                      self.groups, self.deformable_groups)
@@ -148,6 +152,8 @@ class ModulatedDeformConvPack(ModulatedDeformConv):
         self.conv_offset_mask.bias.data.zero_()
 
     def forward(self, x):
+        from ..functions.deform_conv import modulated_deform_conv
+
         out = self.conv_offset_mask(x)
         o1, o2, mask = torch.chunk(out, 3, dim=1)
         offset = torch.cat((o1, o2), dim=1)

--- a/mmdet/ops/dcn/src/deform_conv_cuda.cpp
+++ b/mmdet/ops/dcn/src/deform_conv_cuda.cpp
@@ -62,26 +62,26 @@ void shape_check(at::Tensor input, at::Tensor offset, at::Tensor *gradOutput,
                  at::Tensor weight, int kH, int kW, int dH, int dW, int padH,
                  int padW, int dilationH, int dilationW, int group,
                  int deformable_group) {
-  AT_CHECK(weight.ndimension() == 4,
+  TORCH_CHECK(weight.ndimension() == 4,
            "4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
            "but got: %s",
            weight.ndimension());
 
-  AT_CHECK(weight.is_contiguous(), "weight tensor has to be contiguous");
+  TORCH_CHECK(weight.is_contiguous(), "weight tensor has to be contiguous");
 
-  AT_CHECK(kW > 0 && kH > 0,
+  TORCH_CHECK(kW > 0 && kH > 0,
            "kernel size should be greater than zero, but got kH: %d kW: %d", kH,
            kW);
 
-  AT_CHECK((weight.size(2) == kH && weight.size(3) == kW),
+  TORCH_CHECK((weight.size(2) == kH && weight.size(3) == kW),
            "kernel size should be consistent with weight, ",
            "but got kH: %d kW: %d weight.size(2): %d, weight.size(3): %d", kH,
            kW, weight.size(2), weight.size(3));
 
-  AT_CHECK(dW > 0 && dH > 0,
+  TORCH_CHECK(dW > 0 && dH > 0,
            "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
-  AT_CHECK(
+  TORCH_CHECK(
       dilationW > 0 && dilationH > 0,
       "dilation should be greater than 0, but got dilationH: %d dilationW: %d",
       dilationH, dilationW);
@@ -97,7 +97,7 @@ void shape_check(at::Tensor input, at::Tensor offset, at::Tensor *gradOutput,
     dimw++;
   }
 
-  AT_CHECK(ndim == 3 || ndim == 4, "3D or 4D input tensor expected but got: %s",
+  TORCH_CHECK(ndim == 3 || ndim == 4, "3D or 4D input tensor expected but got: %s",
            ndim);
 
   long nInputPlane = weight.size(1) * group;
@@ -109,7 +109,7 @@ void shape_check(at::Tensor input, at::Tensor offset, at::Tensor *gradOutput,
   long outputWidth =
       (inputWidth + 2 * padW - (dilationW * (kW - 1) + 1)) / dW + 1;
 
-  AT_CHECK(nInputPlane % deformable_group == 0,
+  TORCH_CHECK(nInputPlane % deformable_group == 0,
            "input channels must divide deformable group size");
 
   if (outputWidth < 1 || outputHeight < 1)
@@ -119,27 +119,27 @@ void shape_check(at::Tensor input, at::Tensor offset, at::Tensor *gradOutput,
         nInputPlane, inputHeight, inputWidth, nOutputPlane, outputHeight,
         outputWidth);
 
-  AT_CHECK(input.size(1) == nInputPlane,
+  TORCH_CHECK(input.size(1) == nInputPlane,
            "invalid number of input planes, expected: %d, but got: %d",
            nInputPlane, input.size(1));
 
-  AT_CHECK((inputHeight >= kH && inputWidth >= kW),
+  TORCH_CHECK((inputHeight >= kH && inputWidth >= kW),
            "input image is smaller than kernel");
 
-  AT_CHECK((offset.size(2) == outputHeight && offset.size(3) == outputWidth),
+  TORCH_CHECK((offset.size(2) == outputHeight && offset.size(3) == outputWidth),
            "invalid spatial size of offset, expected height: %d width: %d, but "
            "got height: %d width: %d",
            outputHeight, outputWidth, offset.size(2), offset.size(3));
 
-  AT_CHECK((offset.size(1) == deformable_group * 2 * kH * kW),
+  TORCH_CHECK((offset.size(1) == deformable_group * 2 * kH * kW),
            "invalid number of channels of offset");
 
   if (gradOutput != NULL) {
-    AT_CHECK(gradOutput->size(dimf) == nOutputPlane,
+    TORCH_CHECK(gradOutput->size(dimf) == nOutputPlane,
              "invalid number of gradOutput planes, expected: %d, but got: %d",
              nOutputPlane, gradOutput->size(dimf));
 
-    AT_CHECK((gradOutput->size(dimh) == outputHeight &&
+    TORCH_CHECK((gradOutput->size(dimh) == outputHeight &&
               gradOutput->size(dimw) == outputWidth),
              "invalid size of gradOutput, expected height: %d width: %d , but "
              "got height: %d width: %d",
@@ -189,7 +189,7 @@ int deform_conv_forward_cuda(at::Tensor input, at::Tensor weight,
   long outputHeight =
       (inputHeight + 2 * padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
-  AT_CHECK((offset.size(0) == batchSize), "invalid batch size of offset");
+  TORCH_CHECK((offset.size(0) == batchSize), "invalid batch size of offset");
 
   output = output.view({batchSize / im2col_step, im2col_step, nOutputPlane,
                         outputHeight, outputWidth});
@@ -295,7 +295,7 @@ int deform_conv_backward_input_cuda(at::Tensor input, at::Tensor offset,
   long outputHeight =
       (inputHeight + 2 * padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
-  AT_CHECK((offset.size(0) == batchSize), 3, "invalid batch size of offset");
+  TORCH_CHECK((offset.size(0) == batchSize), 3, "invalid batch size of offset");
   gradInput = gradInput.view({batchSize, nInputPlane, inputHeight, inputWidth});
   columns = at::zeros(
       {nInputPlane * kW * kH, im2col_step * outputHeight * outputWidth},
@@ -410,7 +410,7 @@ int deform_conv_backward_parameters_cuda(
   long outputHeight =
       (inputHeight + 2 * padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
-  AT_CHECK((offset.size(0) == batchSize), "invalid batch size of offset");
+  TORCH_CHECK((offset.size(0) == batchSize), "invalid batch size of offset");
 
   columns = at::zeros(
       {nInputPlane * kW * kH, im2col_step * outputHeight * outputWidth},
@@ -490,8 +490,8 @@ void modulated_deform_conv_cuda_forward(
     const int pad_h, const int pad_w, const int dilation_h,
     const int dilation_w, const int group, const int deformable_group,
     const bool with_bias) {
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
-  AT_CHECK(weight.is_contiguous(), "weight tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(weight.is_contiguous(), "weight tensor has to be contiguous");
 
   const int batch = input.size(0);
   const int channels = input.size(1);
@@ -571,8 +571,8 @@ void modulated_deform_conv_cuda_backward(
     int kernel_h, int kernel_w, int stride_h, int stride_w, int pad_h,
     int pad_w, int dilation_h, int dilation_w, int group, int deformable_group,
     const bool with_bias) {
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
-  AT_CHECK(weight.is_contiguous(), "weight tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(weight.is_contiguous(), "weight tensor has to be contiguous");
 
   const int batch = input.size(0);
   const int channels = input.size(1);

--- a/mmdet/ops/dcn/src/deform_pool_cuda.cpp
+++ b/mmdet/ops/dcn/src/deform_pool_cuda.cpp
@@ -32,7 +32,7 @@ void deform_psroi_pooling_cuda_forward(
     at::Tensor top_count, const int no_trans, const float spatial_scale,
     const int output_dim, const int group_size, const int pooled_size,
     const int part_size, const int sample_per_part, const float trans_std) {
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
 
   const int batch = input.size(0);
   const int channels = input.size(1);
@@ -57,8 +57,8 @@ void deform_psroi_pooling_cuda_backward(
     const int no_trans, const float spatial_scale, const int output_dim,
     const int group_size, const int pooled_size, const int part_size,
     const int sample_per_part, const float trans_std) {
-  AT_CHECK(out_grad.is_contiguous(), "out_grad tensor has to be contiguous");
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(out_grad.is_contiguous(), "out_grad tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
 
   const int batch = input.size(0);
   const int channels = input.size(1);

--- a/mmdet/ops/masked_conv/functions/masked_conv.py
+++ b/mmdet/ops/masked_conv/functions/masked_conv.py
@@ -2,13 +2,14 @@ import math
 import torch
 from torch.autograd import Function
 from torch.nn.modules.utils import _pair
-from .. import masked_conv2d_cuda
 
 
 class MaskedConv2dFunction(Function):
 
     @staticmethod
     def forward(ctx, features, mask, weight, bias, padding=0, stride=1):
+        from .. import masked_conv2d_cuda
+
         assert mask.dim() == 3 and mask.size(0) == 1
         assert features.dim() == 4 and features.size(0) == 1
         assert features.size()[2:] == mask.size()[1:]

--- a/mmdet/ops/masked_conv/src/masked_conv2d_cuda.cpp
+++ b/mmdet/ops/masked_conv/src/masked_conv2d_cuda.cpp
@@ -17,9 +17,9 @@ int MaskedCol2imForwardLaucher(const at::Tensor col, const int height,
                                const at::Tensor mask_w_idx, const int mask_cnt,
                                at::Tensor im);
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
 #define CHECK_CONTIGUOUS(x) \
-  AT_CHECK(x.is_contiguous(), #x, " must be contiguous ")
+  TORCH_CHECK(x.is_contiguous(), #x, " must be contiguous ")
 #define CHECK_INPUT(x) \
   CHECK_CUDA(x);       \
   CHECK_CONTIGUOUS(x)

--- a/mmdet/ops/masked_conv/src/masked_conv2d_kernel.cu
+++ b/mmdet/ops/masked_conv/src/masked_conv2d_kernel.cu
@@ -67,7 +67,7 @@ int MaskedIm2colForwardLaucher(const at::Tensor bottom_data, const int height,
                 output_size, bottom_data_, height, width, kernel_h, kernel_w,
                 pad_h, pad_w, mask_h_idx_, mask_w_idx_, mask_cnt, top_data_);
       }));
-  THCudaCheck(cudaGetLastError());
+  TORCH_CHECK(cudaGetLastError() == cudaSuccess);
   return 1;
 }
 
@@ -108,6 +108,6 @@ int MaskedCol2imForwardLaucher(const at::Tensor bottom_data, const int height,
                 output_size, bottom_data_, height, width, channels, mask_h_idx_,
                 mask_w_idx_, mask_cnt, top_data_);
       }));
-  THCudaCheck(cudaGetLastError());
+  TORCH_CHECK(cudaGetLastError() == cudaSuccess);
   return 1;
 }

--- a/mmdet/ops/nms/nms_wrapper.py
+++ b/mmdet/ops/nms/nms_wrapper.py
@@ -2,7 +2,6 @@ import numpy as np
 import torch
 
 from . import nms_cuda, nms_cpu
-from .soft_nms_cpu import soft_nms_cpu
 
 
 def nms(dets, iou_thr, device_id=None):
@@ -50,6 +49,8 @@ def nms(dets, iou_thr, device_id=None):
 
 
 def soft_nms(dets, iou_thr, method='linear', sigma=0.5, min_score=1e-3):
+    from .soft_nms_cpu import soft_nms_cpu
+
     if isinstance(dets, torch.Tensor):
         is_tensor = True
         dets_np = dets.detach().cpu().numpy()

--- a/mmdet/ops/nms/src/nms_cuda.cpp
+++ b/mmdet/ops/nms/src/nms_cuda.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <torch/extension.h>
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
 
 at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh);
 

--- a/mmdet/ops/roi_align/functions/roi_align.py
+++ b/mmdet/ops/roi_align/functions/roi_align.py
@@ -1,12 +1,12 @@
 from torch.autograd import Function
 
-from .. import roi_align_cuda
-
 
 class RoIAlignFunction(Function):
 
     @staticmethod
     def forward(ctx, features, rois, out_size, spatial_scale, sample_num=0):
+        from .. import roi_align_cuda
+
         if isinstance(out_size, int):
             out_h = out_size
             out_w = out_size
@@ -37,6 +37,8 @@ class RoIAlignFunction(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        from .. import roi_align_cuda
+
         feature_size = ctx.feature_size
         spatial_scale = ctx.spatial_scale
         sample_num = ctx.sample_num

--- a/mmdet/ops/roi_align/src/roi_align_cuda.cpp
+++ b/mmdet/ops/roi_align/src/roi_align_cuda.cpp
@@ -17,9 +17,9 @@ int ROIAlignBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
                             const int pooled_height, const int pooled_width,
                             at::Tensor bottom_grad);
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
 #define CHECK_CONTIGUOUS(x) \
-  AT_CHECK(x.is_contiguous(), #x, " must be contiguous ")
+  TORCH_CHECK(x.is_contiguous(), #x, " must be contiguous ")
 #define CHECK_INPUT(x) \
   CHECK_CUDA(x);       \
   CHECK_CONTIGUOUS(x)

--- a/mmdet/ops/roi_align/src/roi_align_kernel.cu
+++ b/mmdet/ops/roi_align/src/roi_align_kernel.cu
@@ -142,7 +142,7 @@ int ROIAlignForwardLaucher(const at::Tensor features, const at::Tensor rois,
                 sample_num, channels, height, width, pooled_height,
                 pooled_width, top_data);
       }));
-  THCudaCheck(cudaGetLastError());
+  TORCH_CHECK(cudaGetLastError() == cudaSuccess);
   return 1;
 }
 
@@ -289,6 +289,6 @@ int ROIAlignBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
                 channels, height, width, pooled_height, pooled_width,
                 bottom_diff);
       }));
-  THCudaCheck(cudaGetLastError());
+  TORCH_CHECK(cudaGetLastError() == cudaSuccess);
   return 1;
 }

--- a/mmdet/ops/roi_pool/functions/roi_pool.py
+++ b/mmdet/ops/roi_pool/functions/roi_pool.py
@@ -1,13 +1,13 @@
 import torch
 from torch.autograd import Function
 
-from .. import roi_pool_cuda
-
 
 class RoIPoolFunction(Function):
 
     @staticmethod
     def forward(ctx, features, rois, out_size, spatial_scale):
+        from .. import roi_pool_cuda
+
         if isinstance(out_size, int):
             out_h = out_size
             out_w = out_size
@@ -36,6 +36,8 @@ class RoIPoolFunction(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        from .. import roi_pool_cuda
+
         assert grad_output.is_cuda
         spatial_scale = ctx.spatial_scale
         feature_size = ctx.feature_size

--- a/mmdet/ops/roi_pool/src/roi_pool_cuda.cpp
+++ b/mmdet/ops/roi_pool/src/roi_pool_cuda.cpp
@@ -16,9 +16,9 @@ int ROIPoolBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
                            const int num_rois, const int pooled_h,
                            const int pooled_w, at::Tensor bottom_grad);
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
 #define CHECK_CONTIGUOUS(x) \
-  AT_CHECK(x.is_contiguous(), #x, " must be contiguous ")
+  TORCH_CHECK(x.is_contiguous(), #x, " must be contiguous ")
 #define CHECK_INPUT(x) \
   CHECK_CUDA(x);       \
   CHECK_CONTIGUOUS(x)

--- a/mmdet/ops/roi_pool/src/roi_pool_kernel.cu
+++ b/mmdet/ops/roi_pool/src/roi_pool_kernel.cu
@@ -98,7 +98,7 @@ int ROIPoolForwardLaucher(const at::Tensor features, const at::Tensor rois,
                 channels, height, width, pooled_h, pooled_w, top_data,
                 argmax_data);
       }));
-  THCudaCheck(cudaGetLastError());
+  TORCH_CHECK(cudaGetLastError() == cudaSuccess);
   return 1;
 }
 
@@ -151,6 +151,6 @@ int ROIPoolBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
                 scalar_t(spatial_scale), channels, height, width, pooled_h,
                 pooled_w, bottom_diff);
       }));
-  THCudaCheck(cudaGetLastError());
+  TORCH_CHECK(cudaGetLastError() == cudaSuccess);
   return 1;
 }

--- a/mmdet/ops/sigmoid_focal_loss/functions/sigmoid_focal_loss.py
+++ b/mmdet/ops/sigmoid_focal_loss/functions/sigmoid_focal_loss.py
@@ -1,13 +1,13 @@
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 
-from .. import sigmoid_focal_loss_cuda
-
 
 class SigmoidFocalLossFunction(Function):
 
     @staticmethod
     def forward(ctx, input, target, gamma=2.0, alpha=0.25):
+        from .. import sigmoid_focal_loss_cuda
+
         ctx.save_for_backward(input, target)
         num_classes = input.shape[1]
         ctx.num_classes = num_classes
@@ -21,6 +21,8 @@ class SigmoidFocalLossFunction(Function):
     @staticmethod
     @once_differentiable
     def backward(ctx, d_loss):
+        from .. import sigmoid_focal_loss_cuda
+
         input, target = ctx.saved_tensors
         num_classes = ctx.num_classes
         gamma = ctx.gamma

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=18", "pytest-runner", "Cython", "numpy", "torch"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -140,10 +140,9 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.6',
         ],
         license='Apache License 2.0',
-        setup_requires=['pytest-runner', 'cython', 'numpy'],
         tests_require=['pytest'],
         install_requires=[
-            'mmcv>=0.2.6', 'numpy', 'matplotlib', 'six', 'terminaltables',
+            'mmcv==0.2.10', 'numpy', 'matplotlib', 'six', 'terminaltables',
             'pycocotools', 'torch>=1.1'
         ],
         ext_modules=[

--- a/tools/demo.py
+++ b/tools/demo.py
@@ -3,7 +3,7 @@ import argparse
 import os
 import os.path as osp
 import sys
-sys.path.insert(0, osp.join(osp.dirname(osp.abspath(__file__)), '../'))
+#sys.path.insert(0, osp.join(osp.dirname(osp.abspath(__file__)), '../'))
 import time
 import cv2
 import torch


### PR DESCRIPTION
This branch contains changes to make Pedestron work with CUDA 11.7.

**IMPORTANT**: This is _not_ mergeable, as it breaks compilation for lower versions of CUDA and PyTorch, and it is _not_ a trivially usable version, but it works for me, so I figured I'd share it here for reference & potential improvement by others.

I was trying to get Pedestron running and after struggling with older CUDA versions and compatibility to Ampere GPUs I figured I'd give porting the Code to the newer version instead a go, which in the end worked.

# Deployment
## Environment
Run on Debian 11 with CUDA 11.7 and a RTX3060Ti.

I created a virutalenv for the dependencies.
<details>
<summary>package list</summary>
```
⇒  pip3 freeze
addict==2.4.0
certifi==2022.9.24
charset-normalizer==2.1.1
contourpy==1.0.5
cycler==0.11.0
Cython==0.29.32
fonttools==4.37.3
idna==3.4
kiwisolver==1.4.4
matplotlib==3.6.0
mmcv==0.2.10
mmdet==0.6.0+746cdce
mmengine==0.1.0
numpy==1.23.3
opencv-python==4.6.0.66
packaging==21.3
Pillow==9.2.0
pycocotools==2.0.5
pyparsing==3.0.9
python-dateutil==2.8.2
PyYAML==6.0
requests==2.28.1
scipy==1.9.1
six==1.16.0
termcolor==2.0.1
terminaltables==3.1.10
torch==1.13.0.dev20220929+cu117
torchvision==0.14.0.dev20220929+cu117
typing-extensions==4.3.0
urllib3==1.26.12
yapf==0.32.0
```
</details>

`torch` and `torchvision` had to be installed via `pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu117/torch_nightly.html`, I read that the `torch+cu117` syntax should work to, but it didn't for me.

## Building
Activate the venv and run:
```
python3 setup.py install
```
As a workaround for `pip3 install .` which didn't work, as the build environment was different from the venv.

## Execution
Run the demo as described in the project readme.

# Hints for integration
This is a very rough changeset, little more than a proof of concept.
If someone were to try and refine it into proper support for more versions of CUDA & PyTorch, here are some hints for how to do that.

I applied three groups of changes to make Pedestron work with my CUDA & PyTorch versions:
- [Avoid circular imports](https://github.com/hasanirtiza/Pedestron/commit/14ea9e64a5f3ecebdd991a430c03d563083e9b3c): I moved file-level imports in Python to the respective functions.
- [Replace `AT_CHECK` macro with `TORCH_CHECK`](https://github.com/hasanirtiza/Pedestron/commit/a3c1d4af1d41b9cf5f60508349acd21cd6a1313b) as described in #131 
- [Replace THC function family](https://github.com/hasanirtiza/Pedestron/commit/adcd25f5377294e11b568529a46255678cb04c49)

along with some changes to the project setup.

The circular dependency issue may well be a non-issue due to the `tools/demo.py` import of the current working directory over the installed one which (I think) [I removed](https://github.com/hasanirtiza/Pedestron/commit/e9d498b8ff7cc2304346dcf4501f7610b5bc7854) later.
The changes to CUDA & C++ code should be sanitized by providing headers which define appropriate functions/macros depending on the detected CUDA/PyTorch versions.
Moreover, someone with actual understanding should validate that there are no sideeffects introduced by the changes.
Lastly, I started changing the project description in `pyproject.toml` and `setup.py` to be more self-contained, currently these files don't reflect reality when it comes to supported versions, these should be explicitly encoded (e.g., there seems to be a PyTorch version beyond which the current code-base doesn't work, also I constrained `mmcv` to `0.2.10` because that worked for be, probably there's more versions that will work), s.t. the package can be more easily deloyed.